### PR TITLE
Rename imports from ase.ga to ase_ga

### DIFF
--- a/oganesson/genetic_algorithms/__init__.py
+++ b/oganesson/genetic_algorithms/__init__.py
@@ -1,22 +1,22 @@
 from ase.io import write
-from ase.ga import get_raw_score
-from ase.ga.data import DataConnection
-from ase.ga.population import Population
-from ase.ga.utilities import closest_distances_generator, CellBounds
-from ase.ga.ofp_comparator import OFPComparator
-from ase.ga.offspring_creator import OperationSelector
-from ase.ga.standardmutations import StrainMutation
-from ase.ga.soft_mutation import SoftMutation
-from ase.ga.cutandsplicepairing import CutAndSplicePairing
+from ase_ga import get_raw_score
+from ase_ga.data import DataConnection
+from ase_ga.population import Population
+from ase_ga.utilities import closest_distances_generator, CellBounds
+from ase_ga.ofp_comparator import OFPComparator
+from ase_ga.offspring_creator import OperationSelector
+from ase_ga.standardmutations import StrainMutation
+from ase_ga.soft_mutation import SoftMutation
+from ase_ga.cutandsplicepairing import CutAndSplicePairing
 from oganesson.genetic_algorithms.particle_mutations import (
     Poor2richPermutation,
     Rich2poorPermutation,
 )
 from ase import Atoms
 from ase.data import atomic_numbers
-from ase.ga.startgenerator import StartGenerator
-from ase.ga.data import PrepareDB
-from ase.ga import set_raw_score
+from ase_ga.startgenerator import StartGenerator
+from ase_ga.data import PrepareDB
+from ase_ga import set_raw_score
 from oganesson.ogstructure import OgStructure
 import os
 from typing import List

--- a/oganesson/genetic_algorithms/particle_mutations.py
+++ b/oganesson/genetic_algorithms/particle_mutations.py
@@ -1,9 +1,9 @@
 import numpy as np
 from operator import itemgetter
 from oganesson.ogstructure import OgStructure
-from ase.ga.offspring_creator import OffspringCreator
-from ase.ga.utilities import get_distance_matrix
-from ase.ga.particle_mutations import Mutation
+from ase_ga.offspring_creator import OffspringCreator
+from ase_ga.utilities import get_distance_matrix
+from ase_ga.particle_mutations import Mutation
 from ase import Atoms
 
 def get_nndist(atoms, distance_matrix, rmax):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     keywords=["ai", "machine learning", 'material science'],
     install_requires=[
         "ase",
+        "ase_ga",
         "pandas",
         "numpy",
         "pymatgen",


### PR DESCRIPTION
Starting with [ASE version 3.27](https://ase-lib.org/releasenotes.html#version-3-27-0) the ase.ga module was moved to a standalone project, ase_ga. This causes the following error when attempting to use oganesson with a new installation:

```
ImportError: Cannot import ase_ga.
The ase.ga code has moved to a separate project, ase_ga:
https://github.com/dtu-energy/ase-ga .
Please install it using e.g. pip install ase-ga.
Please import from ase_ga what would previously be imported from ase.ga.
ase.ga placeholders will be removed in a future release.
```

PR simply adds `ase_ga` as dependency and fixes imports. Otherwise, consider locking the ASE dependency to 3.26.